### PR TITLE
Add support for multiple-element jQuery container at init (synced paginators)

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -82,10 +82,20 @@
           var el = self.render(true);
 
           // Add extra className to the pagination element
-            if (attributes.className) {
+          if (attributes.className) {
             el.addClass(attributes.className);
           }
 
+          // Append/prepend pagination element to the container
+          var elClones = [];
+          container.each(function(index, element) {
+            var elClone = el.clone(true);
+            $(element)[attributes.position === 'bottom' ? 'append' : 'prepend'](elClone);
+            elClones.push(elClone);
+          })
+
+          // Convert the clones array of elements into a jQuery set. Update "el" to this new set of "els".
+          el = $(elClones).map(function () { return this.toArray(); });
           model.el = el;
 
           // Append/prepend pagination element to the container


### PR DESCRIPTION
Modified the logic that inserts the initial `paginationjs` element into the container, so that our model element jQuery sobject has a reference to multiple inserted `paginationjs` elements.
Whenever we make a change and listen to our model element jQuery object, it will be linked to our multiple elements (and thus, make them work in sync).

More testing should be made though.