### PR TITLE
Modify the locator options a BUG

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -574,7 +574,8 @@
         if (Helpers.isObject(dataSource)) {
           try {
             $.each(locator.split('.'), function(index, item) {
-              filteredData = (filteredData ? filteredData : dataSource)[item];
+              var data = filteredData ? filteredData : dataSource;
+              filteredData = data[item]?data[item]:[];
             });
           }
           catch (e) {


### PR DESCRIPTION
When can't get locator, returns an empty array filteredData , rather than an error.
When I set a locator to the `data.list`, the java api  return  this : 
```javascript
{ 
  code:1,
  data:{
      list:[   
          ...
      ]
  }
}
```  
Sometimes, when no data  that return this :
```javascript
{ 
  code:1,
  data:null
}
```  
 At this moment the filterDataByLocator will throw a error , and the paginationjs cannot be instantiated

So I think that should set a default value : 

```javascript  

$.each(locator.split('.'), function(index, item) {
       var data = filteredData ? filteredData : dataSource;
      filteredData = data[item]?data[item]:[];
 });

```
