### PR TITLE
Adds support for first page index server-side of zero

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -382,8 +382,9 @@
 
         var postData = {};
         var alias = attributes.alias || {};
+        var firstPageIsZero = attributes.firstPageIsZero || false;
         postData[alias.pageSize ? alias.pageSize : 'pageSize'] = pageSize;
-        postData[alias.pageNumber ? alias.pageNumber : 'pageNumber'] = pageNumber;
+        postData[alias.pageNumber ? alias.pageNumber : 'pageNumber'] = firstPageIsZero ? pageNumber -1 : pageNumber;
 
         var ajaxParams = $.isFunction(attributes.ajax) ? attributes.ajax() : attributes.ajax;
         var formatAjaxParams = {
@@ -886,6 +887,9 @@
 
   // Instance defaults
   $.fn[pluginName].defaults = {
+
+    // First page index is zero rather than 1?
+    firstPageIsZero: false,
 
     // Data source
     // Array | String | Function | Object


### PR DESCRIPTION
Our platform backend indexes pages starting with zero rather than 1.

I'm sure we are not the only ones, so this pull request makes a trivial change to decrement the passed page number value when the optional 'firstPageIsZero' boolean attribute is true.