### PR TITLE
Implement pageLink parameter

### DIFF
--- a/docs/en.md
+++ b/docs/en.md
@@ -130,6 +130,27 @@ Number of data items per page.
 
 If you want to show all pages, just set it to `null`.
 
+### pageLink <em>string (default ``)</em>
+`pageLink` customizes the anchor href attribute in the pagination page buttons, for SEO purposes mostly.
+
+By default, they use `<a>{{INDEX}}</a>`. 
+
+By setting a string in `pageLink`, it becomes `<a href="{{pageLink}}">{{INDEX}}</a>`.
+
+If you use the special string `{{index}}` inside your `pageLink`, the link will be customized with the current index.
+
+Example:
+
+pageLink: `/mysite/products/?page={{index}}`
+
+will render:
+
+`<a href="/mysite/products?page=1">1</a>`
+
+`<a href="/mysite/products?page=2">2</a>`
+
+etc.
+
 ### callback <em>function(data, pagination)</em>
 Used to customize item's innerHTML, will be invoked on each paging.
 

--- a/examples/pagination.html
+++ b/examples/pagination.html
@@ -41,6 +41,8 @@
     <div id="pagination-demo2"></div>
     <div class="data-container"></div>
     <div id="pagination-demo3"></div>
+    <div class="data-container"></div>
+    <div id="pagination-demo4"></div>
   </section>
 </div>
 
@@ -168,6 +170,52 @@ $(function() {
       }
     })
   })('demo3');
+
+  (function(name) {
+    var container = $('#pagination-' + name);
+    if (!container.length) return;
+    var sources = function () {
+      var result = [];
+
+      for (var i = 1; i < 196; i++) {
+        result.push(i);
+      }
+
+      return result;
+    }();
+
+    var options = {
+      dataSource: sources,
+      pageLink: '/mysite/products/?page={{index}}', //to show the page button href attribute
+      pageNumber: 5,    //to show how the next/prev links are calculated
+      callback: function (response, pagination) {
+        window.console && console.log(response, pagination);
+
+        var dataHtml = '<ul>';
+
+        $.each(response, function (index, item) {
+          dataHtml += '<li>' + item + '</li>';
+        });
+
+        dataHtml += '</ul>';
+
+        container.prev().html(dataHtml);
+      }
+    };
+
+    //$.pagination(container, options);
+
+    container.addHook('beforeInit', function () {
+      window.console && console.log('beforeInit...');
+    });
+    container.pagination(options);
+
+    container.addHook('beforePageOnClick', function () {
+      window.console && console.log('beforePageOnClick...');
+      //return false
+    });
+  })('demo4');
+  
 })
 </script>
 </body>

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -141,7 +141,18 @@
 
       getPageLinkTag: function(index) {
         var pageLink = attributes.pageLink;
-        return pageLink ? `<a href="${pageLink}">${index}</a>` : `<a>${index}</a>`;
+        let pageIndex = index;
+        let total = attributes.totalNumber;
+        let currentPage = attributes.pageNumber;
+        switch (index){
+            case attributes.prevText:
+                pageIndex = (currentPage>1)?currentPage-1:1;
+                break;
+            case attributes.nextText:
+                pageIndex= (currentPage<total)?currentPage+1:total;
+                break;
+        }
+        return pageLink ? `<a href="${pageLink.replace('{{index}}', pageIndex)}">${index}</a>` : `<a>${index}</a>`;
       },
 
       // Generate HTML for page numbers


### PR DESCRIPTION
This PR implements the `pageLink` parameter, with page index substitution. 
This will help with SEO, as search engines will be able to pick up page links.

See also https://github.com/superRaytin/paginationjs/issues/46 .